### PR TITLE
:pencil2: Fix docstring typo

### DIFF
--- a/src/retrie/retrie.py
+++ b/src/retrie/retrie.py
@@ -291,6 +291,6 @@ class Replacer(Checklist):
 
         Args:
             text (str): String to search & replace.
-            count (int): Amount of occurences to replace. If 0 or emitted, replace all.
+            count (int): Amount of occurences to replace. If 0 or omitted, replace all.
         """
         return self.compiled.sub(self._replace, text, count=count)


### PR DESCRIPTION
Fixes a typo in the `retrie.Replacer.replace()` docstring.